### PR TITLE
CouponID를 간접적으로 받게 수정했어요

### DIFF
--- a/frontend/teemo/src/components/Stamp.js
+++ b/frontend/teemo/src/components/Stamp.js
@@ -15,7 +15,7 @@ class Stamp extends Component {
 	render() {
 		return (
 			<div className="Stamp">
-				<Reveal active={this.props.isStamped} animated='fade' onClick={this.props.isStamped ? null : this.onClick}>
+				<Reveal active={this.props.isStamped} animated='fade' disabled={!this.props.isStamped} onClick={this.props.isStamped ? null : this.onClick}>
 					<Reveal.Content visible>
 						<Image circular size='small' src={coverImage} />
 					</Reveal.Content>

--- a/frontend/teemo/src/pages/CustomerPage.js
+++ b/frontend/teemo/src/pages/CustomerPage.js
@@ -38,6 +38,16 @@ class CustomerPage extends Component {
 			});
 	}
 
+	onClickCoupon(couponID) {
+		console.log("Click Coupon");
+		if(this.state.targetCouponID === '') {
+			this.state.targetCouponID = couponID
+		}
+		else {
+			this.state.targetCouponID = ''
+		}
+	}	
+
 	render() {
 		if (!this.props.statefunction.isLoggedIn) {
 			return <Redirect to="/"/>
@@ -54,7 +64,7 @@ class CustomerPage extends Component {
 //     ))}
 //   </div>
 // )
-		// console.log(this.state.couponList);
+		 //console.log(this.state.couponList);
 		return (
 			<Container textAlign='center'>
 			<LogoutButton/>
@@ -73,8 +83,9 @@ class CustomerPage extends Component {
 					<Grid.Column>
 						{this.state.couponList ?
 						this.state.couponList.map(coupon => (
-							<Segment key={Math.random()}>
+							<Segment key={Math.random()} onClick={(e) => this.onClickCoupon(coupon.coupon.id, e)}>
 								{`[id: ${coupon.coupon.id}] [account: ${coupon.coupon.store.account}] [address: ${coupon.coupon.store.address}] [stamp_count: ${coupon.coupon.stamp_count}]`}
+							<CouponPanel stampCount={coupon.coupon.stamp_count} onClickStamp={err => err}/>
 							</Segment>
 						))
 						: null}

--- a/frontend/teemo/src/pages/SignUpStorePage.js
+++ b/frontend/teemo/src/pages/SignUpStorePage.js
@@ -140,7 +140,7 @@ class SignUpStorePage extends Component {
 					<Grid>
 						<Grid.Row centered>
 							<Grid.Column width={6}>
-							<h2>Sign up customer</h2>
+							<h2>Sign up store</h2>
 							<Form onSubmit={this.onSubmitSignUp}>
 								<Form.Field>
 								<Form.Input type="text" onChange = {this.captureId} value={this.state.id} label="Account" placeholder="honggildong"/>


### PR DESCRIPTION
#37 에 관한 내용이므로 customer_page 브랜치에 머지됩니다.
그러므로 이걸 먼저 머지하고 #37 을 머지하는 게 간편합니다.

1. Store page에서 사용한 'CouponPanel'이라는 컴포넌트를 Customer page의 쿠폰리스트의 각 쿠폰 Segment 마다 뜨게끔 넣었고
2. 각 쿠폰 Segment를 클릭하면 이제 자동으로 couponID가 들어갑니다 다시 누르면 없어집니다
3. Store sign up page 제목이 Sign up customer로 되어있어서 수정했어요~